### PR TITLE
Improve make checks

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/Makefile
+++ b/terraform-google-{{cookiecutter.module_name}}/Makefile
@@ -54,10 +54,6 @@ check_docker:
 check_base_files:
 	@source test/make.sh && basefiles
 
-.PHONY: check_shebangs
-check_shebangs:
-	@source test/make.sh && check_bash
-
 .PHONY: check_trailing_whitespace
 check_trailing_whitespace:
 	@source test/make.sh && check_trailing_whitespace
@@ -69,8 +65,7 @@ test_check_headers:
 
 .PHONY: check_headers
 check_headers:
-	@echo "Checking file headers"
-	@python test/verify_boilerplate.py
+	@source test/make.sh && check_headers
 
 # Integration tests
 .PHONY: test_integration

--- a/terraform-google-{{cookiecutter.module_name}}/helpers/combine_docfiles.py
+++ b/terraform-google-{{cookiecutter.module_name}}/helpers/combine_docfiles.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please note that this file was generated from
+# [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
 # Please make sure to contribute relevant changes upstream!
 
 ''' Combine file from:
@@ -32,8 +33,8 @@ import os
 import re
 import sys
 
-insert_separator_regex = '(.*?\[\^\]\:\ \(autogen_docs_start\))(.*?)(\n\[\^\]\:\ \(autogen_docs_end\).*?$)'  # noqa: E501
-exclude_separator_regex = '(.*?)Copyright 20\d\d Google LLC.*?limitations under the License.(.*?)$'  # noqa: E501
+insert_separator_regex = r'(.*?\[\^\]\:\ \(autogen_docs_start\))(.*?)(\n\[\^\]\:\ \(autogen_docs_end\).*?$)'  # noqa: E501
+exclude_separator_regex = r'(.*?)Copyright 20\d\d Google LLC.*?limitations under the License.(.*?)$'  # noqa: E501
 
 if len(sys.argv) != 3:
     sys.exit(1)
@@ -54,5 +55,5 @@ replace_content = groups[0] + groups[1]
 
 # Find where to put the replacement content, overwrite the input file
 groups = re.match(insert_separator_regex, input, re.DOTALL).groups(0)
-output = groups[0] + replace_content + groups[2]
+output = groups[0] + replace_content + groups[2] + "\n"
 open(sys.argv[1], "w").write(output)

--- a/terraform-google-{{cookiecutter.module_name}}/test/fixtures/all_examples/variables.tf
+++ b/terraform-google-{{cookiecutter.module_name}}/test/fixtures/all_examples/variables.tf
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  description = "The project ID to deploy to"
+}

--- a/terraform-google-{{cookiecutter.module_name}}/test/make.sh
+++ b/terraform-google-{{cookiecutter.module_name}}/test/make.sh
@@ -17,84 +17,141 @@
 # Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
 # Please make sure to contribute relevant changes upstream!
 
-# This function checks to make sure that every
-# shebang has a '- e' flag, which causes it
-# to exit on error
-function check_bash() {
-find . -name "*.sh" | while IFS= read -d '' -r file;
-do
-  if [[ "$file" != *"bash -e"* ]];
-  then
-    echo "$file is missing shebang with -e";
-    exit 1;
-  fi;
-done;
+# Create a temporary directory that's auto-cleaned, even if the process aborts.
+DELETE_AT_EXIT="$(mktemp -d)"
+finish() {
+  [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
+}
+trap finish EXIT
+# Create a temporary file in the auto-cleaned up directory while avoiding
+# overwriting TMPDIR for other processes.
+# shellcheck disable=SC2120 # (Arguments may be passed, e.g. maketemp -d)
+maketemp() {
+  TMPDIR="${DELETE_AT_EXIT}" mktemp "$@"
+}
+
+# find_files is a helper to exclude .git directories and match only regular
+# files to avoid double-processing symlinks.
+find_files() {
+  local pth="$1"
+  shift
+  find "${pth}" '(' -path '*/.git' -o -path '*/.terraform' ')' \
+    -prune -o -type f "$@"
+}
+
+# Compatibility with both GNU and BSD style xargs.
+compat_xargs() {
+  local compat=()
+  # Test if xargs is GNU or BSD style.  GNU xargs will succeed with status 0
+  # when given --no-run-if-empty and no input on STDIN.  BSD xargs will fail and
+  # exit status non-zero If xargs fails, assume it is BSD style and proceed.
+  # stderr is silently redirected to avoid console log spam.
+  if xargs --no-run-if-empty </dev/null 2>/dev/null; then
+    compat=("--no-run-if-empty")
+  fi
+  xargs "${compat[@]}" "$@"
 }
 
 # This function makes sure that the required files for
 # releasing to OSS are present
 function basefiles() {
-  echo "Checking for required files"
-  test -f LICENSE || echo "Missing LICENSE"
-  test -f README.md || echo "Missing README.md"
+  local fn required_files="LICENSE README.md"
+  echo "Checking for required files ${required_files}"
+  for fn in ${required_files}; do
+    test -f "${fn}" || echo "Missing required file ${fn}"
+  done
 }
 
 # This function runs the hadolint linter on
 # every file named 'Dockerfile'
 function docker() {
   echo "Running hadolint on Dockerfiles"
-  find . -name "Dockerfile" -exec hadolint {} \;
+  find_files . -name "Dockerfile" -print0 \
+    | compat_xargs -0 hadolint
 }
 
 # This function runs 'terraform validate' against all
-# files ending in '.tf'
+# directory paths which contain *.tf files.
 function check_terraform() {
   echo "Running terraform validate"
-  #shellcheck disable=SC2156
-  find . -name "*.tf" -not -path "./**/.terraform/*" -not -path "./test/fixtures/shared/*" -not -path "./test/fixtures/all_examples/*" -exec bash -c 'terraform validate --check-variables=false $(dirname "{}")' \;
+  find_files . -name "*.tf" -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u \
+    | grep -xv './test/fixtures/shared' \
+    | compat_xargs -t -n1 terraform validate --check-variables=false
 }
 
 # This function runs 'go fmt' and 'go vet' on every file
 # that ends in '.go'
 function golang() {
   echo "Running go fmt and go vet"
-  find . -name "*.go" -exec go fmt {} \;
-  find . -name "*.go" -exec go vet {} \;
+  find_files . -name "*.go" -print0 | compat_xargs -0 -n1 go fmt
+  find_files . -name "*.go" -print0 | compat_xargs -0 -n1 go vet
 }
 
 # This function runs the flake8 linter on every file
 # ending in '.py'
 function check_python() {
   echo "Running flake8"
-  find . -name "*.py" -exec flake8 {} \;
+  find_files . -name "*.py" -print0 | compat_xargs -0 flake8
+  return 0
 }
 
 # This function runs the shellcheck linter on every
 # file ending in '.sh'
 function check_shell() {
   echo "Running shellcheck"
-  find . -name "*.sh" -exec shellcheck -x {} \;
+  find_files . -name "*.sh" -print0 | compat_xargs -0 shellcheck -x
 }
 
 # This function makes sure that there is no trailing whitespace
 # in any files in the project.
 # There are some exclusions
 function check_trailing_whitespace() {
-  echo "The following lines have trailing whitespace"
-  grep -r '[[:blank:]]$' --exclude-dir=".terraform" --exclude-dir=".kitchen" --exclude="*.png" --exclude="*.pyc" --exclude-dir=".git" .
+  local rc
+  echo "Checking for trailing whitespace"
+  find_files . -print \
+    | grep -v -E '\.(pyc|png)$' \
+    | compat_xargs grep -H -n '[[:blank:]]$'
   rc=$?
-  if [ $rc = 0 ]; then
-    exit 1
+  if [[ ${rc} -eq 0 ]]; then
+    return 1
   fi
 }
 
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
-  TMPFILE=$(mktemp)
-  #shellcheck disable=2006,2086
-  for j in `for i in $(find . -type f | grep \.tf$) ; do dirname $i ; done | sort -u` ; do
-    terraform-docs markdown "$j" > "$TMPFILE"
-    python helpers/combine_docfiles.py "$j"/README.md "$TMPFILE"
+  local path tmpfile
+  while read -r path; do
+    if [[ -e "${path}/README.md" ]]; then
+      # shellcheck disable=SC2119
+      tmpfile="$(maketemp)"
+      echo "terraform-docs markdown ${path}"
+      terraform-docs markdown "${path}" > "${tmpfile}"
+      helpers/combine_docfiles.py "${path}"/README.md "${tmpfile}"
+    else
+      echo "Skipping ${path} because README.md does not exist."
+    fi
+  done < <(find_files . -name '*.tf' -print0 \
+    | compat_xargs -0 -n1 dirname \
+    | sort -u)
+}
+
+function prepare_test_variables() {
+  echo "Preparing terraform.tfvars files for integration tests"
+  #shellcheck disable=2044
+  for i in $(find ./test/fixtures -type f -name terraform.tfvars.sample); do
+    destination=${i/%.sample/}
+    if [ ! -f "${destination}" ]; then
+      cp "${i}" "${destination}"
+      echo "${destination} has been created. Please edit it to reflect your GCP configuration."
+    fi
   done
-  rm -f "$TMPFILE"
+}
+
+function check_headers() {
+  echo "Checking file headers"
+  # Use the exclusion behavior of find_files
+  find_files . -type f -print0 \
+    | compat_xargs -0 python test/verify_boilerplate.py
 }

--- a/terraform-google-{{cookiecutter.module_name}}/test/test_verify_boilerplate.py
+++ b/terraform-google-{{cookiecutter.module_name}}/test/test_verify_boilerplate.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please note that this file was generated from
+# [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
 # Please make sure to contribute relevant changes upstream!
 
 ''' A simple test for the verify_boilerplate python script.

--- a/terraform-google-{{cookiecutter.module_name}}/test/verify_boilerplate.py
+++ b/terraform-google-{{cookiecutter.module_name}}/test/verify_boilerplate.py
@@ -19,7 +19,8 @@
 # https://github.com/kubernetes/test-infra/blob/master/hack
 # /verify_boilerplate.py
 
-# Please note that this file was generated from [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
+# Please note that this file was generated from
+# [terraform-google-module-template](https://github.com/terraform-google-modules/terraform-google-module-template).
 # Please make sure to contribute relevant changes upstream!
 from __future__ import print_function
 import argparse


### PR DESCRIPTION
These improvements are back-ported from the approved pull requests:

 * https://github.com/terraform-google-modules/terraform-google-startup-scripts/pull/5
 * https://github.com/terraform-google-modules/terraform-google-startup-scripts/pull/6

Without this patch there are a number of annoyances with the make
checks.  This patch fixes the following:

 1. Checks execute against .git/ and .terraform/ directories
 2. terraform validate executes redundantly

The patch refactors make.sh to use a general find | xargs pattern with a
single function to manage exclusion lists.

check_shebangs is removed because `#! /bin/bash -e` should not be used
because it does not take effect if the script is called via bash
<filename>.  Instead, calling `set -e` is preferred.

Add .terraform to the make check exclusion list

Use find_files to gain exclusion with check_headers

Without this patch the check_headers task descends into .terraform and
.git directories which causes false positive errors.

This patch switches check_headers to the find_files method, which has a
shared exclusion list containing .git and .terraform.

Fix combine_docfiles.py W605 and newline error

This patch fixes three issues with the make generate_docs task:

 1. Directories with *.tf files and no README.md throw errors.
 2. Newline at EOF is stripped from README.md
 3. W605 pylint warnings on combine_docfiles.py

Fix `terraform validate` errors with newly created module

Without this patch a new module fails with the following error:

    Running terraform validate
    Error: output 'project_id': unknown variable referenced: 'project_id'; define it with a 'variable' block
    Error: output 'bucket_name': unknown module referenced: example
    make: *** [check_terraform] Error 1

This directory is not a complete module and therefor won't pass
validation checks.  The code itself is still validated when symlinked
into a complete module, e.g. ./test/fixtures/simple_example/outputs.tf
-> ../shared/outputs.tf

Fix grep file not found error

Without this patch grep fails when it encounters the dangling symlink
created initially when invoking cookiecutter.

= Testing

```
cookiecutter https://github.com/jeffmccune/terraform-google-module-template.git
You've downloaded terraform-google-module-template before. Is it okay to delete and re-download it? [yes]: yes
module_name []: test5
```

```
cd terraform-module-test5
make

Running shellcheck
Running flake8
Running go fmt and go vet
Running terraform validate
terraform validate --check-variables=false .
terraform validate --check-variables=false ./examples/simple_example
terraform validate --check-variables=false ./test/fixtures/all_examples
terraform validate --check-variables=false ./test/fixtures/simple_example
Running hadolint on Dockerfiles
Checking for required files LICENSE README.md
Testing the validity of the header check
..
----------------------------------------------------------------------
Ran 2 tests in 0.028s

OK
Checking file headers
Checking for trailing whitespace
Generating markdown docs with terraform-docs
terraform-docs markdown .
terraform-docs markdown ./examples/simple_example
Skipping ./test/fixtures/all_examples because README.md does not exist.
Skipping ./test/fixtures/shared because README.md does not exist.
Skipping ./test/fixtures/simple_example because README.md does not exist.
```