### PR TITLE
Add `test/ci_integration.sh` to capture CI pattern, update Makefile

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/Makefile
+++ b/terraform-google-{{cookiecutter.module_name}}/Makefile
@@ -70,12 +70,7 @@ check_headers:
 # Integration tests
 .PHONY: test_integration
 test_integration:
-	bundle install
-	bundle exec kitchen create
-	bundle exec kitchen converge
-	bundle exec kitchen converge
-	bundle exec kitchen verify
-	bundle exec kitchen destroy
+	test/ci_integration.sh
 
 .PHONY: generate_docs
 generate_docs:
@@ -90,48 +85,71 @@ version:
 .PHONY: docker_run
 docker_run:
 	docker run --rm -it \
+		-e PROJECT_ID \
+		-e BUCKET_NAME \
+		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && exec /bin/bash"
 
 .PHONY: docker_create
 docker_create:
 	docker run --rm -it \
+		-e PROJECT_ID \
+		-e BUCKET_NAME \
+		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen create"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen create"
 
 .PHONY: docker_converge
 docker_converge:
 	docker run --rm -it \
+		-e PROJECT_ID \
+		-e BUCKET_NAME \
+		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen converge && kitchen converge"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen converge"
 
 .PHONY: docker_verify
 docker_verify:
 	docker run --rm -it \
+		-e PROJECT_ID \
+		-e BUCKET_NAME \
+		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen verify"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen verify"
 
 .PHONY: docker_destroy
 docker_destroy:
 	docker run --rm -it \
+		-e PROJECT_ID \
+		-e BUCKET_NAME \
+		-e SERVICE_ACCOUNT_JSON \
 		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
 		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
 		-v $(CURDIR):/cft/workdir \
 		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
-		/bin/bash -c "kitchen destroy"
+		/bin/bash -c "source test/ci_integration.sh && setup_environment && kitchen destroy"
 
 .PHONY: test_integration_docker
-test_integration_docker: docker_create docker_converge docker_verify docker_destroy
-	@echo "Running test-kitchen tests in docker"
+test_integration_docker:
+	docker run --rm -it \
+		-e PROJECT_ID \
+		-e BUCKET_NAME \
+		-e SERVICE_ACCOUNT_JSON \
+		-e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=${CREDENTIALS_PATH} \
+		-e GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_PATH} \
+		-v $(CURDIR):/cft/workdir \
+		${DOCKER_REPO_BASE_KITCHEN_TERRAFORM} \
+		make test_integration

--- a/terraform-google-{{cookiecutter.module_name}}/test/ci_integration.sh
+++ b/terraform-google-{{cookiecutter.module_name}}/test/ci_integration.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Always clean up.
+DELETE_AT_EXIT="$(mktemp -d)"
+finish() {
+  echo 'BEGIN: finish() trap handler' >&2
+  kitchen destroy "$SUITE"
+  [[ -d "${DELETE_AT_EXIT}" ]] && rm -rf "${DELETE_AT_EXIT}"
+  echo 'END: finish() trap handler' >&2
+}
+
+# Map the input parameters provided by Concourse CI, or whatever mechanism is
+# running the tests to Terraform input variables.  Also setup credentials for
+# use with kitchen-terraform, inspec, and gcloud.
+setup_environment() {
+  local tmpfile
+  tmpfile="$(mktemp)"
+  echo "${SERVICE_ACCOUNT_JSON}" > "${tmpfile}"
+
+  # gcloud variables
+  export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE="${tmpfile}"
+  # Application default credentials (Terraform google provider and inspec-gcp)
+  export GOOGLE_APPLICATION_CREDENTIALS="${tmpfile}"
+
+  # Terraform variables
+  export TF_VAR_project_id="$PROJECT_ID"
+  export TF_VAR_bucket_name="$BUCKET_NAME"
+}
+
+main() {
+  export SUITE="${SUITE:-}"
+
+  set -eu
+  # Setup trap handler to auto-cleanup
+  export TMPDIR="${DELETE_AT_EXIT}"
+  trap finish EXIT
+
+  # Setup environment variables
+  setup_environment
+  set -x
+
+  # Execute the test lifecycle
+  kitchen create "$SUITE"
+  kitchen converge "$SUITE"
+  kitchen verify "$SUITE"
+}
+
+# if script is being executed and not sourced.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
This commit adds a helper script for configuring and running CI
integration tests, based on the pattern that's arisen within our other
repositories. This also updates the Makefile to pass required
environment variables into the docker container and source the
integration script for environment configuration.