### PR TITLE
Lint-tests splitted to steps for the Cloud Build

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/CHANGELOG.md
+++ b/terraform-google-{{cookiecutter.module_name}}/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Lint-tests splitted to separate steps for the Cloud Build.
+
 ## [0.1.0] - 20XX-YY-ZZ
 
 ### Added

--- a/terraform-google-{{cookiecutter.module_name}}/build/lint.cloudbuild.yaml
+++ b/terraform-google-{{cookiecutter.module_name}}/build/lint.cloudbuild.yaml
@@ -13,9 +13,32 @@
 # limitations under the License.
 
 steps:
-- name: 'gcr.io/cloud-foundation-cicd/cft/developer-tools:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
-  id: 'lint'
-  args: ['/usr/local/bin/test_lint.sh']
+- id: 'lint-pull-image'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+- id: 'lint-documentation'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && check_documentation']
+  waitFor: ['lint-pull-image']
+- id: 'lint-whitespace'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && check_whitespace']
+  waitFor: ['lint-pull-image']
+- id: 'lint-shell'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && check_shell']
+  waitFor: ['lint-pull-image']
+- id: 'lint-headers'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && check_headers']
+  waitFor: ['lint-pull-image']
+- id: 'lint-python'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && check_python']
+  waitFor: ['lint-pul-image']
+- id: 'lint-terraform'
+  name: 'gcr.io/cloud-foundation-cicd/$_DOCKER_IMAGE_DEVELOPER_TOOLS:$_DOCKER_TAG_VERSION_DEVELOPER_TOOLS'
+  args: ['/bin/bash', '-c', 'source /usr/local/bin/task_helper_functions.sh && check_terraform']
+  waitFor: ['lint-pull-image']
 tags:
 - 'ci'
 - 'lint'


### PR DESCRIPTION
Lint-tests splitted to steps for the Cloud Build to make debugging simpler 