### PR TITLE
Set Docker image tag to 0

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/Makefile
+++ b/terraform-google-{{cookiecutter.module_name}}/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.4.5
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/terraform-google-{{cookiecutter.module_name}}/build/int.cloudbuild.yaml
+++ b/terraform-google-{{cookiecutter.module_name}}/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.5'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'

--- a/terraform-google-{{cookiecutter.module_name}}/build/lint.cloudbuild.yaml
+++ b/terraform-google-{{cookiecutter.module_name}}/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.4.5'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'


### PR DESCRIPTION
This branch updates the template to take advantage of the Docker image's major release tag.