### PR TITLE
Remove redundant required_version from main.tf

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/main.tf
+++ b/terraform-google-{{cookiecutter.module_name}}/main.tf
@@ -14,10 +14,6 @@
  * limitations under the License.
  */
 
-terraform {
-  required_version = "~> 0.12.0"
-}
-
 resource "google_storage_bucket" "main" {
   project = var.project_id
   name    = var.bucket_name


### PR DESCRIPTION
It's already specified in [versions.tf](https://github.com/terraform-google-modules/terraform-google-module-template/blob/master/terraform-google-%7B%7Bcookiecutter.module_name%7D%7D/versions.tf).