### PR TITLE
Pin Terraform to ~> 0.12.6

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/versions.tf
+++ b/terraform-google-{{cookiecutter.module_name}}/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12.6"
 }


### PR DESCRIPTION
This pinning will include support of `for_each` while avoiding prematurely including 0.13.