### PR TITLE
Ability to exclude dirs when running `docker_test_lint`

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/Makefile
+++ b/terraform-google-{{cookiecutter.module_name}}/Makefile
@@ -68,6 +68,7 @@ docker_test_integration:
 .PHONY: docker_test_lint
 docker_test_lint:
 	docker run --rm -it \
+		-e EXCLUDE_LINT_DIRS \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
 		/usr/local/bin/test_lint.sh


### PR DESCRIPTION
This PR passes `EXCLUDE_LINT_DIRS` env to docker container to exclude directories from linting rules.

**BEFORE**
```
➜ make docker_test_lint     
docker run --rm -it \
                -v "/Users/limc/Documents/development/gcp/terraform-google-vpc-network-peering":/workspace \
                gcr.io/cloud-foundation-cicd/cft/developer-tools:0 \
                /usr/local/bin/test_lint.sh
Checking for documentation generation
Checking for trailing whitespace
Checking for missing newline at end of file
Error: No newline at end of file ./terraform-google-vpc-network-peering.iml
Error: No newline at end of file ./.idea/encodings.xml
Error: No newline at end of file ./.idea/inspectionProfiles/Project_Default.xml
Error: No newline at end of file ./.idea/vcs.xml
Error: No newline at end of file ./.idea/workspace.xml
Error: No newline at end of file ./.idea/modules.xml
Error: No newline at end of file ./.idea/dictionaries
Error: No newline at end of file ./.idea/misc.xml
Error: No newline at end of file ./.idea/compiler.xml
Running shellcheck
Checking file headers
7 files have incorrect boilerplate headers:
.idea/compiler.xml
.idea/encodings.xml
.idea/inspectionProfiles/Project_Default.xml
.idea/misc.xml
.idea/modules.xml
.idea/vcs.xml
.idea/workspace.xml
Running flake8
Running terraform fmt
Running terraform validate
terraform_validate . 
Success! The configuration is valid.

terraform_validate ./test/fixtures/successful_peering 
Success! The configuration is valid.

Error: The following tests have failed: check_whitespace check_headers
make: *** [docker_test_lint] Error 2
```

**AFTER**
```
➜ EXCLUDE_LINT_DIRS="\./\.idea"  make docker_test_lint
docker run --rm -it \
                -e EXCLUDE_LINT_DIRS \
                -v "/Users/limc/Documents/development/gcp/terraform-google-vpc-network-peering":/workspace \
                gcr.io/cloud-foundation-cicd/cft/developer-tools:0 \
                /usr/local/bin/test_lint.sh
Checking for documentation generation
Checking for trailing whitespace
Checking for missing newline at end of file
Error: No newline at end of file ./terraform-google-vpc-network-peering.iml
Running shellcheck
Checking file headers
Running flake8
Running terraform fmt
Running terraform validate
terraform_validate . 
Success! The configuration is valid.

terraform_validate ./test/fixtures/successful_peering 
Success! The configuration is valid.

Error: The following tests have failed: check_whitespace
make: *** [docker_test_lint] Error 1