### PR TITLE
Fix example ci test setup

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/test/setup/main.tf
+++ b/terraform-google-{{cookiecutter.module_name}}/test/setup/main.tf
@@ -16,13 +16,14 @@
 
 module "project" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 8.0"
 
   name              = "ci-{{ cookiecutter.module_name|replace('-', '_') }}"
   random_project_id = "true"
   org_id            = var.org_id
   folder_id         = var.folder_id
   billing_account   = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/terraform-google-{{cookiecutter.module_name}}/test/setup/versions.tf
+++ b/terraform-google-{{cookiecutter.module_name}}/test/setup/versions.tf
@@ -19,9 +19,9 @@ terraform {
 }
 
 provider "google" {
-  version = "~> 2.13.0"
+  version = "~> 3.25.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.13.0"
+  version = "~> 3.25.0"
 }


### PR DESCRIPTION
Test project creation using PF [can be flaky ](https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/pull/559#issuecomment-643247733)due to https://github.com/terraform-providers/terraform-provider-google/issues/6377

This bumps the provider to a version with the fix and also a newer PF version.