### PR TITLE
fix: update release-please config

### DIFF
--- a/terraform-google-{{cookiecutter.module_name}}/.github/release-please.yml
+++ b/terraform-google-{{cookiecutter.module_name}}/.github/release-please.yml
@@ -1,2 +1,4 @@
 releaseType: terraform-module
 handleGHRelease: true
+primaryBranch: main
+bumpMinorPreMajor: true


### PR DESCRIPTION
- new repos are auto configured to use `main`. release-please [injects default config](https://github.com/googleapis/repo-automation-bots/blob/6bc25aa0c47dfc4786b68467394b0751d195464f/packages/release-please/src/config-constants.ts#L42) if not explicitly set resulting in release-pr not being created
- also set `bumpMinorPreMajor` as new modules wont need major release immediately 
